### PR TITLE
Hide unneeded additional views when recycling

### DIFF
--- a/src/XamU.Infrastructure/Controls/ItemsControl.cs
+++ b/src/XamU.Infrastructure/Controls/ItemsControl.cs
@@ -211,6 +211,11 @@ namespace XamarinUniversity.Controls
             var itemStyle = ItemStyle;
             var template = ItemTemplate;
             var visuals = stack.Children;
+            
+            for (int i = 0; i < this.stack.Children.Count; i++)
+            {
+                this.stack.Children[i].IsVisible = i < newValue.Count;
+            }
 
             for (int i = 0; i < newValue.Count; i++) {
                 var dataItem = newValue [i];


### PR DESCRIPTION
If the ItemsSource changes from e.g. 3 items to 2 items, the third item will still be visible because it's never hidden or removed. This change fixes that by hiding all stack children that will not be recycled.